### PR TITLE
Chore/#1 Spring Rest Docs 설치 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.6'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.self'
@@ -30,3 +31,42 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/******* Start Spring Rest Docs *******/
+
+ext {
+    snippetsDir = file("$buildDir/generated-snippets")
+}
+
+test {
+    useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file("src/main/resources/static/docs")
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into "static/docs"
+    }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("$buildDir/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
+}
+
+/******* End Spring Rest Docs *******/


### PR DESCRIPTION
## 🔥 Related Issue

close: #1 

## 📝 Description

Spring Rest Docs는 테스트를 실행하고, 성공적으로 수행된 경우 REST API 문서를 생성합니다. 
이번 프로젝트의 목표인 테스트 코드를 잘 작성해보고자, 도입하게 되었습니다.

또한 이번 프로젝트는 API 문서를 생성하여, 정리를 하기에, `Swagger`는 어울리지 않다는 판단을 하였습니다.

## ⭐️ Review

`Asciidoctor` 마크업 언어 파일을 테스트가 성공하면, 자동으로 만들어줘야 하기 때문에, 다른 의존성 추가보다 더 복잡하고, 이해하기 어려웠습니다.