### PR TITLE
Fix/#31 회원 비밀번호 돈 컬럼 수정

### DIFF
--- a/src/main/java/com/self/egoboard/domain/user/entity/User.java
+++ b/src/main/java/com/self/egoboard/domain/user/entity/User.java
@@ -29,11 +29,16 @@ public class User extends BaseEntity {
   private static final int MAX_EMAIL_ADDRESS_LENGTH = 45;
   private static final int MAX_USERNAME_LENGTH = 15;
   private static final int MAX_NICKNAME_LENGTH = 15;
+  private static final int MAX_MONEY_LENGTH = 11;
+  private static final int START_MONEY = 0;
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "user_id", nullable = false, updatable = false)
   private Long id;
+
+  @Column(name = "money", nullable = false, length = MAX_MONEY_LENGTH)
+  private Integer money;
 
   @Column(name = "username", nullable = false, length = MAX_USERNAME_LENGTH, updatable = false)
   private String username;
@@ -58,6 +63,7 @@ public class User extends BaseEntity {
   public User(String username, String password, String emailAddress, String nickname,
       Address address) {
     this.username = username;
+    this.money = START_MONEY;
     this.password = password;
     this.emailAddress = emailAddress;
     this.nickname = nickname;

--- a/src/main/java/com/self/egoboard/domain/user/entity/User.java
+++ b/src/main/java/com/self/egoboard/domain/user/entity/User.java
@@ -38,7 +38,7 @@ public class User extends BaseEntity {
   @Column(name = "username", nullable = false, length = MAX_USERNAME_LENGTH, updatable = false)
   private String username;
 
-  @Column(name = "money", nullable = false, length = MAX_PASSWORD_LENGTH)
+  @Column(name = "password", nullable = false, length = MAX_PASSWORD_LENGTH)
   private String password;
 
   @Column(name = "email_address", nullable = false, length = MAX_EMAIL_ADDRESS_LENGTH)

--- a/src/test/java/com/self/egoboard/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/self/egoboard/domain/user/application/UserServiceTest.java
@@ -29,4 +29,15 @@ class UserServiceTest extends IntegrationTest {
 
     Assertions.assertThat(findUser.isEmpty()).isFalse();
   }
+
+  @Test
+  @DisplayName("유저의 돈이 0원으로 생성이된다.")
+  void should_zeroMoney_when_createUser() {
+    em.flush();
+    em.clear();
+
+    Optional<User> findUser = userRepository.findById(user.getId());
+
+    Assertions.assertThat(findUser.get().getMoney()).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #31 

## 📝 Description

비밀번호의 DB컬럼명을 수정하였습니다.

회원가입을 하면, 무조건 0으로 가지는 `money`컬럼을 추가하였습니다. 

## ⭐️ Review

